### PR TITLE
Add get_matching_product_for_id and some fixes

### DIFF
--- a/lib/mws/auth.ex
+++ b/lib/mws/auth.ex
@@ -13,6 +13,7 @@ defmodule Mws.Auth do
       |> Map.put("SignatureMethod", "HmacSHA256")
       |> Map.put("SignatureVersion", "2")
       |> Enum.sort
+      |> Enum.filter(fn ({_k, v}) -> !is_nil(v) end)
 
     query ++ [
         Signature: build_signature(config, verb, uri, query)

--- a/lib/mws/auth.ex
+++ b/lib/mws/auth.ex
@@ -9,7 +9,7 @@ defmodule Mws.Auth do
       |> Map.put("AWSAccessKeyId", config.access_key_id)
       |> Map.put("SellerId", config.seller_id)
       |> Map.put("MarketplaceId", config.marketplace_id)
-      |> Map.put("MSWAuthToken", config.mws_auth_token)
+      |> Map.put("MWSAuthToken", config.mws_auth_token)
       |> Map.put("SignatureMethod", "HmacSHA256")
       |> Map.put("SignatureVersion", "2")
       |> Enum.sort

--- a/lib/mws/endpoints/product.ex
+++ b/lib/mws/endpoints/product.ex
@@ -19,4 +19,26 @@ defmodule Mws.Product do
 
     Mws.Client.request(conn, :post, url)
   end
+
+  def get_matching_product_for_id(conn, id, id_type \\ "ASIN")
+  def get_matching_product_for_id(conn, id, id_type) when is_bitstring(id) do
+    get_matching_product_for_id(conn, [id], id_type)
+  end
+  def get_matching_product_for_id(conn, ids, id_type) when is_list(ids) do
+    query =
+      %{
+        "Action"   => "GetMatchingProductForId",
+        "Version"  => "2011-10-01",
+        "IdList" => ids,
+        "IdType" => id_type
+      }
+      |> Mws.Utils.restructure("IdList", "Id")
+
+    url = %URI{
+      path: "/Products/2011-10-01",
+      query: query
+    }
+
+    Mws.Client.request(conn, :post, url)
+  end
 end


### PR DESCRIPTION
- Fixed typo on MWSAuthToken param
- Removed query params with nil values from the request (I don't have or need the MWSAuthToken - so filters it out when it isn't specified)
- Added `get_matching_product_for_id`

`get_matching_product_for_id` matches the existing `get_matching_product` functions with an additional 3rd `id_type` param which defaults to "ASIN" - so it can be used in the same way as the previous function. This endpoint is newer and has better rate limits than `get_matching_product`